### PR TITLE
Allowing people to use custom templates in dev mode

### DIFF
--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -18,8 +18,7 @@ module.exports = function getBaseConfig (spec) {
     },
     plugins: [
       new HtmlPlugin({
-        html: spec.html,
-        isDev: spec.isDev
+        html: spec.html
       })
     ],
     module: {

--- a/lib/html-plugin.js
+++ b/lib/html-plugin.js
@@ -43,14 +43,6 @@ HJSPlugin.prototype.apply = function (compiler) {
       return defaultHtml(assets)
     }
 
-    // if this is dev, stop here
-    if (self.config.isDev) {
-      self.addAssets(compiler, {
-        'index.html': assets.defaultTemplate()
-      })
-      return callback()
-    }
-
     // handle both sync and async versions
     if (htmlFunction.length === 2) {
       htmlFunction(assets, function (err, result) {


### PR DESCRIPTION
I ran into an issue where I wanted to use a custom html template for both development and production builds, because I need to load legacy javascript and specify various meta headers, etc.

After looking at the code, it looks like `html-plugin.js` creates a default index.html when `isDev` is `true`.  This is preventing me from specifying my own `index.html` for development builds.  Therefore, I suggest removing it.

Of course, I could be misunderstanding it.