### PR TITLE
Autoprefix all configured style loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When this happens, you'll want to run the following to install the related depen
 Included here for you copy/paste enjoyment:
 
 ```
-npm i --save autoprefixer-stylus babel babel-loader css-loader react-hot-loader style-loader stylus-loader url-loader webpack-dev-server yeticss
+npm i --save autoprefixer-core babel babel-loader css-loader postcss-loader react-hot-loader style-loader stylus-loader url-loader webpack-dev-server yeticss
 ```
 
 ## usage

--- a/index.js
+++ b/index.js
@@ -98,15 +98,15 @@ module.exports = function (opts) {
     config.module.loaders.push(
       {
         test: /\.css$/,
-        loader: 'style-loader!css-loader'
+        loader: 'style-loader!css-loader!postcss-loader'
       },
       {
         test: /\.styl$/,
-        loader: 'style-loader!css-loader!stylus-loader'
+        loader: 'style-loader!css-loader!postcss-loader!stylus-loader'
       },
       {
         test: /\.less$/,
-        loader: 'style-loader!css-loader!less-loader'
+        loader: 'style-loader!css-loader!postcss-loader!less-loader'
       }
     )
 
@@ -136,15 +136,15 @@ module.exports = function (opts) {
     config.module.loaders.push(
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader')
       },
       {
         test: /\.styl$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!stylus-loader')
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!stylus-loader')
       },
       {
         test: /\.less/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!less-loader')
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!less-loader')
       }
     )
   }

--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -1,5 +1,5 @@
 var yeticss = require('yeticss')
-var autoPrefixer = require('autoprefixer-stylus')
+var autoPrefixer = require('autoprefixer-core')
 var HtmlPlugin = require('./html-plugin')
 
 module.exports = function getBaseConfig (spec) {
@@ -45,7 +45,8 @@ module.exports = function getBaseConfig (spec) {
       ]
     },
     stylus: {
-      use: [yeticss(), autoPrefixer()]
-    }
+      use: [yeticss()]
+    },
+    postcss: [autoPrefixer()]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "autoprefixer-stylus": "*",
+    "autoprefixer-core": "*",
     "babel": "*",
     "babel-loader": "*",
     "css-loader": "*",
+    "postcss-loader": "*",
     "react-hot-loader": "*",
     "style-loader": "*",
     "stylus-loader": "*",


### PR DESCRIPTION
This uses `autoprefixer-core` and `postcss-loader` to add autoprefixing to stylus, less and plain css. This also removed autoprefixer-stylus since that is no longer necessary.

closes #12