### PR TITLE
dont need .styl extension in resolve

### DIFF
--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -12,8 +12,7 @@ module.exports = function getBaseConfig (spec) {
       extensions: [
         '',
         '.js',
-        '.json',
-        '.styl'
+        '.json'
       ]
     },
     plugins: [


### PR DESCRIPTION
I don't having this extension here is necessary since we set up `.styl` as a loader elsewhere. http://webpack.github.io/docs/configuration.html#resolve-extensions 