### PR TITLE
add json-loader to peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When this happens, you'll want to run the following to install the related depen
 Included here for your copy/paste enjoyment:
 
 ```
-npm i --save autoprefixer-core babel babel-loader css-loader postcss-loader react-hot-loader style-loader stylus-loader url-loader webpack-dev-server yeticss
+npm i --save autoprefixer-core babel babel-loader css-loader json-loader postcss-loader react-hot-loader style-loader stylus-loader url-loader webpack-dev-server yeticss
 ```
 
 ## usage

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "babel": "*",
     "babel-loader": "*",
     "css-loader": "*",
+    "json-loader": "*",
     "postcss-loader": "*",
     "react-hot-loader": "*",
     "style-loader": "*",


### PR DESCRIPTION
We reference the `json-loader` in the [base config](https://github.com/HenrikJoreteg/hjs-webpack/blob/c8d40cbdada54bc243ef382871a970f0a997d50a/lib/base-config.js#L34), so I think it should be installed to peer deps.

The other option is to add something to the "Other loaders" section, but requiring `.json` files seems common enough that we should support it as easily as possible.