### PR TITLE
Add missing comma to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ I usually add something like the following scripts:
 ```
 "scripts": {
   "start": "webpack-dev-server",
-  "prebuild": "rm -rf public && mkdir public"
+  "prebuild": "rm -rf public && mkdir public",
   "build": "NODE_ENV=production webpack",
   "deploy": "npm run build && surge -p public -d somedomain.com"
 }


### PR DESCRIPTION
In history's shortest changelog, I have added a missing comma to the "scripts" npm config. If you, like me, just copy paste things blindly, this will ensure that at the package.json is valid and you don't have to hunt for the missing comma.