### PR TITLE
use process.cwd() over env var for root

### DIFF
--- a/lib/get-package.js
+++ b/lib/get-package.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 var findRoot = require('find-root')
-var rootFolder = findRoot(process.env.PWD)
+var rootFolder = findRoot(process.cwd())
 
 module.exports = function (pack) {
   var result = getPackage(pack)


### PR DESCRIPTION
I think this is the problem with #20, where the `PWD` env var doesn't exist so it find the `package.json` for `hjs-webpack` instead. This switches to the node builtin method of getting the current working directory.

Fixes #20 