### PR TITLE
Fix for example deps

### DIFF
--- a/examples/assets-and-index-html/package.json
+++ b/examples/assets-and-index-html/package.json
@@ -3,7 +3,26 @@
   "version": "1.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "dependencies": {
-    "hjs-webpack": "latest"
+    "react": "^0.13.3"
+  },
+  "devDependencies": {
+    "autoprefixer-core": "^5.1.11",
+    "babel": "^5.4.2",
+    "babel-core": "^5.4.2",
+    "babel-loader": "^5.1.0",
+    "css-loader": "^0.12.1",
+    "file-loader": "^0.8.1",
+    "hjs-webpack": "^2.2.2",
+    "json-loader": "^0.5.1",
+    "node-libs-browser": "^0.5.0",
+    "postcss-loader": "^0.4.3",
+    "react-hot-loader": "^1.2.7",
+    "style-loader": "^0.12.2",
+    "stylus-loader": "^1.1.1",
+    "url-loader": "^0.5.5",
+    "webpack": "^1.9.6",
+    "webpack-dev-server": "^1.8.2",
+    "yeticss": "^6.0.6"
   },
   "license": "MIT",
   "main": "app.js",

--- a/examples/just-assets-no-html/package.json
+++ b/examples/just-assets-no-html/package.json
@@ -3,7 +3,26 @@
   "version": "1.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "dependencies": {
-    "hjs-webpack": "latest"
+    "react": "^0.13.3"
+  },
+  "devDependencies": {
+    "autoprefixer-core": "^5.1.11",
+    "babel": "^5.4.2",
+    "babel-core": "^5.4.2",
+    "babel-loader": "^5.1.0",
+    "css-loader": "^0.12.1",
+    "file-loader": "^0.8.1",
+    "hjs-webpack": "^2.2.2",
+    "json-loader": "^0.5.1",
+    "node-libs-browser": "^0.5.0",
+    "postcss-loader": "^0.4.3",
+    "react-hot-loader": "^1.2.7",
+    "style-loader": "^0.12.2",
+    "stylus-loader": "^1.1.1",
+    "url-loader": "^0.5.5",
+    "webpack": "^1.9.6",
+    "webpack-dev-server": "^1.8.2",
+    "yeticss": "^6.0.6"
   },
   "license": "MIT",
   "main": "app.js",

--- a/examples/prerendered-html-files/package.json
+++ b/examples/prerendered-html-files/package.json
@@ -3,7 +3,27 @@
   "version": "1.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "dependencies": {
-    "hjs-webpack": "latest"
+    "ampersand-router": "^3.0.2",
+    "react": "^0.13.3"
+  },
+  "devDependencies": {
+    "autoprefixer-core": "^5.1.11",
+    "babel": "^5.4.2",
+    "babel-core": "^5.4.2",
+    "babel-loader": "^5.1.0",
+    "css-loader": "^0.12.1",
+    "file-loader": "^0.8.1",
+    "hjs-webpack": "^2.2.2",
+    "json-loader": "^0.5.1",
+    "node-libs-browser": "^0.5.0",
+    "postcss-loader": "^0.4.3",
+    "react-hot-loader": "^1.2.7",
+    "style-loader": "^0.12.2",
+    "stylus-loader": "^1.1.1",
+    "url-loader": "^0.5.5",
+    "webpack": "^1.9.6",
+    "webpack-dev-server": "^1.8.2",
+    "yeticss": "^6.0.6"
   },
   "license": "MIT",
   "main": "app.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "lodash.defaults": "^3.0.0"
   },
   "devDependencies": {
-    "ampersand-router": "^3.0.2",
     "standard": "^3.1.2"
   },
   "homepage": "https://github.com/henrikjoreteg/hjs-webpack",


### PR DESCRIPTION
**What this does:**
- separate example package.json files in to devDeps and deps
- use full list of deps generated from `npm install hjs-webpack` for devDeps

**Why:**
So while digging into #22 I found this strange behavior. If I took the code for the `prerendered-html-files/src` example and separated it into its own folder and used the `package.json` from this PR, then the example worked. But running `npm install` in the directory if it has just `"dependencies": {"hjs-weback": "latest"}` did not work. From what I could tell, all the same modules were being installed.

The description in #22 is correct, turning off the `DedupePlugin` makes the build work. I also found the commenting out `require('ampersand-router')` also made the build work. I'm not exactly sure but it seems like some combination of `npm install` with `hjs-webpack` already in the `package.json` and the `DedupePlugin` cause the error `Error: No template for dependency: TemplateArgumentDependency`.

I was already pretty far down the rabbit hole when I found the solution so I didn't dig any deeper after I found the fix. I also found a few mentions of this error when Googling but nothing concrete so that's why I'm trying to do a rather full write-up of what I found.

**Other stuffs**
Since I was already changing the package.json files in the examples, I figured it was better to separate them into `dependencies` and `devDependencies` to better mirror what they would look like in real world scenarios.

Closes #22