### PR TITLE
Resolve .jsx files

### DIFF
--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -12,6 +12,7 @@ module.exports = function getBaseConfig (spec) {
       extensions: [
         '',
         '.js',
+        '.jsx',
         '.json'
       ]
     },


### PR DESCRIPTION
This is the only change I've needed so far. Is there a reason (use case) for having `.jsx` registered with the babel loader but not as a resolvable extension?