### PR TITLE
Allow for overriding webpack-dev-server port

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (opts) {
     isDev: isDev,
     package: null,
     replace: null,
-    port: 3000,
+    port: process.env.PORT || 3000,
     hostname: 'localhost',
     html: true,
     urlLoaderLimit: 10000,


### PR DESCRIPTION
I tend to have multiple tmux sessions open with different projects - need to be able to use different ports for the dev server to avoid some hassle.