### PR TITLE
add .scss loader, don't install by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ There's a few loaders configured, but not automatically installed:
 
 `require('styles.less')` and npm install `less-loader`
 
+**sass**
+
+`require('styles.scss')` and npm install `sass-loader`
+
 **jade**
 
 `require('template.jade')` and npm install `jade-loader`

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ There's a few loaders configured, but not automatically installed:
 
 **sass**
 
-`require('styles.scss')` and npm install `sass-loader`
+`require('styles.sass')` or `require('styles.scss')` and npm install `sass-loader`
 
 **jade**
 

--- a/index.js
+++ b/index.js
@@ -117,6 +117,10 @@ module.exports = function (opts) {
       {
         test: /\.less$/,
         loader: 'style-loader!css-loader!postcss-loader!less-loader'
+      },
+      {
+	test: /\.scss$/,
+	loader: 'style-loader!css-loader!postcss-loader!sass-loader'
       }
     )
 
@@ -171,6 +175,10 @@ module.exports = function (opts) {
       {
         test: /\.less$/,
         loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!less-loader')
+      },
+      {
+	test: /\.scss$/,
+	loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader')
       }
     )
   }

--- a/index.js
+++ b/index.js
@@ -121,6 +121,10 @@ module.exports = function (opts) {
       {
 	test: /\.scss$/,
 	loader: 'style-loader!css-loader!postcss-loader!sass-loader'
+      },
+      {
+	test: /\.sass$/,
+	loader: "style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax"
       }
     )
 
@@ -179,6 +183,10 @@ module.exports = function (opts) {
       {
 	test: /\.scss$/,
 	loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader')
+      },
+      {
+	test: /\.sass$/,
+	loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader?indentedSyntax')
       }
     )
   }


### PR DESCRIPTION
Maybe you don't like Sass but it is widely used.
It was simpler to add it than add a generic loader mechanism in user config, but if you want that capability, I can maybe do it  