### PR TITLE
Add react to peer modules command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When this happens, you'll want to run the following to install the related depen
 Included here for your copy/paste enjoyment:
 
 ```
-npm i --save autoprefixer-core babel babel-loader css-loader json-loader postcss-loader react-hot-loader style-loader stylus-loader url-loader webpack-dev-server yeticss
+npm i --save autoprefixer-core babel babel-loader css-loader json-loader postcss-loader react react-hot-loader style-loader stylus-loader url-loader webpack-dev-server yeticss
 ```
 
 ## usage


### PR DESCRIPTION
The module `react-hot-loader` depends on `react-hot-api` that has `react` on peerDependencies.