### PR TITLE
Conditional load optional loaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,11 @@ module.exports = function (opts) {
       new webpack.NoErrorsPlugin()
     ])
 
-    // add react-hot as module loader
-    config.module.loaders[0].loaders.unshift('react-hot')
+    // add react-hot as module loader if it is installed
+    if (isInstalled('react-hot')) {
+      config.module.loaders[0].loaders.unshift('react-hot')
+    }
+
 
     config.module.loaders.push(
       {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var defaults = require('lodash.defaults')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var getBaseConfig = require('./lib/base-config')
 var getPackage = require('./lib/get-package')
+var optionalLoaders = require('./lib/optional-loaders')
+var isInstalled = require('./lib/is-installed')
 
 // figure out if we're running `webpack` or `webpack-dev-server`
 // we'll use this as the default for `isDev`
@@ -109,24 +111,15 @@ module.exports = function (opts) {
       {
         test: /\.css$/,
         loader: 'style-loader!css-loader!postcss-loader'
-      },
-      {
-        test: /\.styl$/,
-        loader: 'style-loader!css-loader!postcss-loader!stylus-loader'
-      },
-      {
-        test: /\.less$/,
-        loader: 'style-loader!css-loader!postcss-loader!less-loader'
-      },
-      {
-        test: /\.scss$/,
-        loader: 'style-loader!css-loader!postcss-loader!sass-loader'
-      },
-      {
-        test: /\.sass$/,
-        loader: 'style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax'
       }
-    )
+    );
+
+    // Add optional loaders
+    optionalLoaders.forEach(function (item) {
+      if (isInstalled(item.pkg)) {
+        config.module.loaders.push(item.config.dev);
+      }
+    });
 
   } else {
     // clear out output folder if so configured
@@ -166,29 +159,19 @@ module.exports = function (opts) {
       })
     )
 
-    // extract in production
     config.module.loaders.push(
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader')
-      },
-      {
-        test: /\.styl$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!stylus-loader')
-      },
-      {
-        test: /\.less$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!less-loader')
-      },
-      {
-        test: /\.scss$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader')
-      },
-      {
-        test: /\.sass$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader?indentedSyntax')
       }
-    )
+    );
+
+    // Add optional loaders
+    optionalLoaders.forEach(function (item) {
+      if (isInstalled(item.pkg)) {
+        config.module.loaders.push(item.config.production);
+      }
+    });
   }
 
   return config

--- a/lib/is-installed.js
+++ b/lib/is-installed.js
@@ -1,0 +1,8 @@
+module.exports = function (name) {
+  try {
+    require.resolve(name)
+    return true
+  } catch (e) {
+    return false
+  }
+}

--- a/lib/optional-loaders.js
+++ b/lib/optional-loaders.js
@@ -1,0 +1,59 @@
+var ExtractTextPlugin = require('extract-text-webpack-plugin')
+
+// All optional loader plugins are listed here
+// `pkg` is the npm name of the loader
+// `config` contains a webpack loader config for development and production
+module.exports = [
+  {
+    pkg:'stylus-loader',
+    config: {
+      dev: {
+        test: /\.styl$/,
+        loader: 'style-loader!css-loader!postcss-loader!stylus-loader'
+      },
+      production: {
+        test: /\.styl$/,
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!stylus-loader')
+      }
+    }
+  },
+  {
+    pkg:'less-loader',
+    config: {
+      dev: {
+        test: /\.less$/,
+        loader: 'style-loader!css-loader!postcss-loader!less-loader'
+      },
+      production: {
+        test: /\.less$/,
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!less-loader')
+      }
+    }
+  },
+  {
+    pkg:'sass-loader',
+    config: {
+      dev: {
+        test: /\.scss$/,
+        loader: 'style-loader!css-loader!postcss-loader!sass-loader'
+      },
+      production: {
+        test: /\.scss$/,
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader')
+      }
+    }
+  },
+  {
+    pkg:'sass-loader',
+    config: {
+      dev: {
+        test: /\.sass$/,
+        loader: 'style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax'
+      },
+      production: {
+        test: /\.sass$/,
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader!sass-loader?indentedSyntax')
+      }
+    }
+  }
+]


### PR DESCRIPTION
Loaders and `react-hot`(#50) are only added to the webpack config if they are installed.

To do this I extracted all "optional" loaders into `lib/optional-loaders.js` and load these conditionally using the `isInstalled` function from `lib/is-installed.js`. 