### PR TITLE
fix when no process.argv[1] is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var isInstalled = require('./lib/is-installed')
 
 // figure out if we're running `webpack` or `webpack-dev-server`
 // we'll use this as the default for `isDev`
-var isDev = process.argv[1].indexOf('webpack-dev-server') !== -1
+var isDev = (process.argv[1] || '').indexOf('webpack-dev-server') !== -1
 
 module.exports = function (opts) {
   checkRequired(opts)


### PR DESCRIPTION
Very simple fix, maybe too simple ;)

Background: This enables usage like this

```
node -p 'require("./webpack.config.js")'
# or 
node -p 'JSON.stringify(require("./webpack.config.js"), 0, 2)' > webpack-config-gen.json
```

to inspect the actual configuration generated by `hjs-webpack`. 

Very handy for people like me using this to get started with `webpack` in general (btw :heart: thanks for this very nice headstart), but then want to learn what actually goes on.