### PR TITLE
Hot loader and source map

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,8 +100,7 @@ module.exports = function (opts) {
 
     // add dev plugins
     config.plugins = config.plugins.concat([
-      new webpack.HotModuleReplacementPlugin(),
-      new webpack.NoErrorsPlugin()
+      new webpack.HotModuleReplacementPlugin()
     ])
 
     // add react-hot as module loader if it is installed

--- a/index.js
+++ b/index.js
@@ -86,7 +86,11 @@ module.exports = function (opts) {
   // dev specific stuff
   if (spec.isDev) {
     // debugging option
-    config.devtool = 'eval'
+    // https://webpack.github.io/docs/configuration.html#devtool
+    // https://github.com/HenrikJoreteg/hjs-webpack/issues/63
+    // Supports original code (before transforms) with pretty good initial
+    // build speed and good rebuild speed
+    config.devtool = 'cheap-module-eval-source-map'
 
     // add dev server and hotloading clientside code
     config.entry.unshift(

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "json-loader": "*",
     "postcss-loader": "*",
     "react": "*",
-    "react-hot-loader": "*",
+    "react-hot-loader": "^1.3.0",
     "style-loader": "*",
     "stylus-loader": "*",
     "url-loader": "*",


### PR DESCRIPTION
Closes #62, #63 

Using `^1.3.0` as the version for `react-hot-loader` in peer deps since the change to remove `NoErrorsPlugin` only landed in that version.