### PR TITLE
Allow for dependency react 0.14.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "css-loader": "*",
     "json-loader": "*",
     "postcss-loader": "*",
-    "react": "*",
+    "react": "* || "^0.14.0-rc1",
     "react-hot-loader": "^1.3.0",
     "style-loader": "*",
     "stylus-loader": "*",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "css-loader": "*",
     "json-loader": "*",
     "postcss-loader": "*",
-    "react": "* || "^0.14.0-rc1",
+    "react": "* || ^0.14.0-rc1",
     "react-hot-loader": "^1.3.0",
     "style-loader": "*",
     "stylus-loader": "*",


### PR DESCRIPTION
It looks like the the wildcard operator does not allow for rc candidates.  This has been discussed [here](https://github.com/npm/npm/issues/8854) and complained about [here](http://stackoverflow.com/questions/31479320/npm-doesnt-recognize-semvers-that-end-with-rc-i-e-release-candidates-ca). 

This is obviously a bit ugly and I wasn't sure if there were a better way of doing this.  Feel free to delete if you decide against it.
