### PR TITLE
Accept React pre-release versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "css-loader": "*",
     "json-loader": "*",
     "postcss-loader": "*",
-    "react": "*",
+    "react": ">0.13.0-alpha || >0.14.0-alpha",
     "react-hot-loader": "^1.3.0",
     "style-loader": "*",
     "stylus-loader": "*",


### PR DESCRIPTION
Unfortunately, npm doesn't treat `*` as compatible with pre-release versions. This would accept anything in the 0.13.x and 0.14.x range.