### PR TITLE
Adding optional support for webpack-dev-server's https mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,14 @@ These options are passed through to the [`webpack-dev-server`](http://webpack.gi
   host, // // pulled from top level option "hostname"
   info: false,
   historyApiFallback: true,
-  hot: true
+  hot: true,
+  https // pulled from top level option "https"
 }
 ```
+
+### `https` (optional, boolean, default: `false`)
+
+This is used to start `webpack-dev-server` with its self signed certificate, so you can load the application with an https url.  It also configures hot module replacement to also use https. 
 
 ### `replace` (optional, object)
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = function (opts) {
     package: null,
     replace: null,
     port: 3000,
+    https: false,
     hostname: 'localhost',
     html: true,
     urlLoaderLimit: 10000,
@@ -94,13 +95,14 @@ module.exports = function (opts) {
 
     // add dev server and hotloading clientside code
     config.entry.unshift(
-      'webpack-dev-server/client?http://' + spec.hostname + ':' + spec.port,
+      'webpack-dev-server/client?' + (spec.https ? 'https://' : 'http://') + spec.hostname + ':' + spec.port,
       'webpack/hot/only-dev-server'
     )
 
     config.devServer = spec.devServer
     config.devServer.port = spec.port
     config.devServer.host = spec.hostname
+    config.devServer.https = spec.https
 
     // add dev plugins
     config.plugins = config.plugins.concat([


### PR DESCRIPTION
I'm in a situation where I'm integrating with Amazon's cloud drive api, and the api requires all hosts calling it to be https.  webpack-dev-server supports https, so I've added a configuration flag (defaulted to false to preserve http mode), documentation, and the code necessary to support either mode.