### PR TITLE
removed default option from template function, and added publicPath option to replace it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+- 4.0.0
+  - Remove `relative` option from template in lieu of a more flexible `publicPath` option.
+
 - 3.1.0
   - Add support for the following loaders: `coffee cjsx typescript livescript`.
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ Your `html` function will be called with a context object that contains the foll
   - `{title: 'your app'}` sets `<title>`
   - `{head: 'any string'}` anything else you want to put in the `head`, other meta tags, or whatnot.
   - `{metaViewport: false}` set to false if you don't want the default viewport tag
-  - `{relative: false}` set to false if you want to turn off relative links `/` useful for gh-pages
+  - `{publicPath: 'http://mycdn.com/'}`  (default `/`) pass in path that will prefix the generated css/js files in the template. Note, there is `output.publicPath` provided by webpack, but doesn't easily allow for switching based on envirnoment. In this method we've got access to `context.isDev` and can easily switch based on that.
   - `{metaTags: {}}` lets you easily add `<meta>` tags to the document head. Takes an object where the key is the `name` and the value is the `content`.
 4. `context.isDev`: boolean specifying whether or not we're in dev mode.
 5. `context.package`: the parsed `package.json` file as an object.

--- a/lib/html-plugin.js
+++ b/lib/html-plugin.js
@@ -6,9 +6,8 @@ function defaultHtml (incomingData) {
     charset: 'utf-8',
     metaViewport: true,
     html: '',
-    relative: false
+    publicPath: '/'
   }, incomingData)
-  var sep = data.relative ? '' : '/'
   var result = ['<!doctype html>']
   var add = function () {
     result.push.apply(result, arguments)
@@ -28,7 +27,7 @@ function defaultHtml (incomingData) {
     add('<title>' + data.title + '</title>')
   }
   if (data.css) {
-    add('<link rel="stylesheet" href="' + sep + data.css + '"/>')
+    add('<link rel="stylesheet" href="' + data.publicPath + data.css + '"/>')
   }
   if (data.head) {
     add(data.head)
@@ -39,7 +38,7 @@ function defaultHtml (incomingData) {
     add(data.html)
   }
   add('</body>')
-  add('<script src="' + sep + data.main + '"></script>')
+  add('<script src="' + data.publicPath + data.main + '"></script>')
   return result.join('')
 }
 


### PR DESCRIPTION
I ran into an issue when trying to build this as part of a project where my target build directory was as a "child" of another static site. This lets me run options like this:

```js

module.exports = getConfig({
  in: 'presentation/root.js',
  out: '../../public/evolution-of-the-web-app',
  clearBeforeBuild: '!(images|static)',
  hostname: hostname || 'odin.local',
  port: port || 3000,
  html: function (context) {
    return context.defaultTemplate({
      html: '<div>' + React.renderToString(React.createElement(Presentatation)) + '</div>',
      head: '<link href="https://fonts.googleapis.com/css?family=Oswald:700" rel="stylesheet" type="text/css">',
      publicPath: context.isDev ? '/' : '/evolution-of-the-web-app/'
    })
  }
})
```

Note that the `out` is outside of this directory, it lets me run the slides for one of my talks as a "standalone" app, but publish them as part of https://slides.joreteg.com

Any thoughts on this @lukekarrys before I merge?