### PR TITLE
Fixing assets-and-index-html and prerendered-html-files examples

### DIFF
--- a/examples/assets-and-index-html/src/styles.styl
+++ b/examples/assets-and-index-html/src/styles.styl
@@ -5,4 +5,4 @@ body
 
 header
   margin-top: 30px
-  background-image: url('./ampersand.svg')
+  background-image: url('./andyet.svg')

--- a/examples/prerendered-html-files/webpack.config.js
+++ b/examples/prerendered-html-files/webpack.config.js
@@ -1,5 +1,5 @@
 // this lets us require files with JSX/ES6 in them
-require('babel/register')
+require('babel-core/register')
 
 // require React and our two React components
 var React = require('react')


### PR DESCRIPTION
- Fixing bad route for background-image on `assets-and-index-html` examples
- Fixing issue with babel core on `prerendered-html-files` example

@lukekarrys : I couldn't figure out what was going on on example number 2. I'm getting a 404 error when I hit `http://localhost:3000`