### PR TITLE
Load .woff2 files with url-loader

### DIFF
--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -92,7 +92,7 @@ module.exports = function getBaseConfig (spec) {
     {
       pkg: 'url-loader',
       config: {
-        test: /\.(otf|eot|svg|ttf|woff)$/,
+        test: /\.(otf|eot|svg|ttf|woff|woff2)$/,
         loader: 'url-loader?limit=' + spec.urlLoaderLimit
       }
     },


### PR DESCRIPTION
I've been using react-bootstrap which requires bootstrap which tries to load a ``woff2`` file, ``glyphicons-halflings-regular.woff2``. This seems to fix the problem.