### PR TITLE
make some changes to font loaders

### DIFF
--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -92,14 +92,42 @@ module.exports = function getBaseConfig (spec) {
     {
       pkg: 'url-loader',
       config: {
-        test: /\.(otf|eot|svg|ttf|woff|woff2)$/,
+        test: /\.otf(\?\S*)?$/,
         loader: 'url-loader?limit=' + spec.urlLoaderLimit
       }
     },
     {
       pkg: 'url-loader',
       config: {
-        test: /\.(jpe?g|png|gif|svg)$/,
+        test: /\.eot(\?\S*)?$/,
+        loader: 'url-loader?limit=' + spec.urlLoaderLimit
+      }
+    },
+    {
+      pkg: 'url-loader',
+      config: {
+        test: /\.svg(\?\S*)?$/,
+        loader: 'url-loader?mimetype=image/svg+xml&limit=' + spec.urlLoaderLimit
+      }
+    },
+    {
+      pkg: 'url-loader',
+      config: {
+        test: /\.ttf(\?\S*)?$/,
+        loader: 'url-loader?mimetype=application/octet-stream&limit=' + spec.urlLoaderLimit
+      }
+    },
+    {
+      pkg: 'url-loader',
+      config: {
+        test: /\.woff2?(\?\S*)?$/,
+        loader: 'url-loader?mimetype=application/font-woff&limit=' + spec.urlLoaderLimit
+      }
+    },
+    {
+      pkg: 'url-loader',
+      config: {
+        test: /\.(jpe?g|png|gif)$/,
         loader: 'url-loader?limit=' + spec.urlLoaderLimit
       }
     },


### PR DESCRIPTION
- Separate them into individual loaders. This will make it easier for users to make changes to ones if they need to.
- Add mimetypes for extensions that I saw in documentation for other projects. I noticed `url-loader` sometimes infers different ones.
- Allow query strings for font loaders since many projects use those.

I looked at [`bootstrap-webpack`](https://github.com/bline/bootstrap-webpack) and [`font-awesome-webpack`](https://github.com/gowravshekar/font-awesome-webpack) to get examples of how other projects suggest to setup loaders and I was able to match both of those with the new loaders.

I created an [example gist](https://gist.github.com/lukekarrys/5bbeafcc4d23ed87ea76#file-readme-md) where I was able to get `hjs-webpack` working with both bootstrap and font-awesome.

Closes #113 