### PR TITLE
Move from react-hot-loader to react-transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ I usually add something like the following scripts:
 
 ```
 "scripts": {
-  "start": "hjs-dev-server webpack.config.js",
+  "start": "hjs-dev-server",
   "build": "webpack",
   "deploy": "npm run build && surge -p public -d somedomain.com"
 }

--- a/README.md
+++ b/README.md
@@ -76,15 +76,6 @@ Here's some more information about the available loaders and plugins and what th
 
 [`jade-loader`](https://www.npmjs.com/package/jade-loader) Require jade files as compiled functions. Extension: `jade`.
 
-
-### Peer dependencies
-
-`hjs-webpack` does have one `peerDependency` on `webpack-dev-server`. In npm `3.x.x` `peerDependencies` will no longer be installed by default. When this happens, you'll want to run the following to manually install it with the following command:
-
-```
-npm install webpack-dev-server --save-dev
-```
-
 ## usage
 
 #### Step 1. install it into your project
@@ -232,7 +223,7 @@ The most common thing you'd probably want to do while using this module would be
 getConfig({
   in: 'src/app.js',
   out: 'public',
-  clearBeforeBuild: '!(images|static)'  
+  clearBeforeBuild: '!(images|static)'
 })
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-#hjs-webpack
+# hjs-webpack
+
+> Warning: If you are upgrading from version `6.0.0` or less, please read the [upgrade guide](#upgrade-guide).
 
 I really dislike setting up build scripts. Most of the time I want to do the exact same thing:
 
@@ -16,7 +18,7 @@ When ready to ship:
   - be ready to just upload it all to something like [surge.sh](http://surge.sh/)
   - sometimes I want to pre-render all known HTML into static HTML files and have React take over once the clientside JS loads.
 
-[webpack](http://webpack.github.io) and the [webpack-dev-server](http://webpack.github.io/docs/webpack-dev-server.html) can do most of those things pretty well out of the box. But, it sure is a pain to set it all up.
+[webpack](http://webpack.github.io) can do most of those things pretty well out of the box. But, it sure is a pain to set it all up.
 
 So, this is just a simplified, opinionated way to configure webpack for development and then build for production. That also supports easily generating more files.
 
@@ -118,7 +120,7 @@ I usually add something like the following scripts:
 
 ```
 "scripts": {
-  "start": "webpack-dev-server",
+  "start": "hjs-dev-server webpack.config.js",
   "build": "webpack",
   "deploy": "npm run build && surge -p public -d somedomain.com"
 }
@@ -234,7 +236,7 @@ So, just to be clear, everything that matches the glob string *within* the out f
 
 A boolean to indicate whether or not everything is in production mode (minified, etc.) or development mode (everything hotloaded and unminified).
 
-By default this value is `true` if the command you ran contains `webpack-dev-server` and `false` otherwise. The option exists here in case you need to override the default.
+By default this value is `true` if the command you ran contains `hjs-dev-server` and `false` otherwise. The option exists here in case you need to override the default.
 
 ### `output.filename` (optional, string)
 
@@ -268,7 +270,7 @@ This is the default threshold to use for whether URLs referenced in stylesheets 
 
 ### `devServer` (optional, object)
 
-These options are passed through to the [`webpack-dev-server`](http://webpack.github.io/docs/webpack-dev-server.html#api) with a few defaults:
+These options are passed through to the `hjs-dev-server` with a few defaults:
 
 ```js
 {
@@ -283,7 +285,7 @@ These options are passed through to the [`webpack-dev-server`](http://webpack.gi
 
 ### `https` (optional, boolean, default: `false`)
 
-This is used to start `webpack-dev-server` with its self signed certificate, so you can load the application with an https url.  It also configures hot module replacement to also use https.
+This is used to start `hjs-dev-server` with its self signed certificate, so you can load the application with an https url.  It also configures hot module replacement to also use https.
 
 ### `replace` (optional, object)
 
@@ -456,6 +458,21 @@ module.exports = config
 ### Changing Babel config
 
 Since `hjs-webpack` already has a babel loader, the easiest way to tweak Babel settings is to create a file at the root of your project called `.babelrc` that contains config settings. See [bablerc docs](https://babeljs.io/docs/usage/babelrc/) for more options.
+
+
+## Upgrade Guide
+
+The hot module loader changed from [react-hot-loader](https://github.com/gaearon/react-hot-loader) to [babel-blugin-react-transform](https://github.com/gaearon/babel-plugin-react-transform). This is a breaking change and means you need to upgrade your installation when trying to use the newest version of hjs-webpack.
+If you want to continue to use hot reloading make sure to add these `devDependencies`
+
+```bash
+$ npm i --save-dev babel-loader babel-plugin-react-transform@^2.0.0-beta1 react-transform-catch-errors react-transform-hmr webpack-hot-middleware
+```
+
+and then you can remove `webpack-dev-server` from your dependencies in `package.json`.
+
+In the `"scripts"` section of your `package.json` you should change `webpack-dev-server` to `hjs-dev-server <path/to/webpack.config.js>`.
+
 
 ## Credits
 

--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -7,7 +7,7 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 
-var configFile = process.argv[2]
+var configFile = process.argv[2] || 'webpack.config.js'
 var config
 try {
   config = require(path.join(process.cwd(), configFile))

--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -24,7 +24,7 @@ var serverConfig = config.devServer
 
 var app = express()
 var compiler = webpack(config)
-console.log(JSON.stringify(config.module, null, 2))
+
 app.use(require('webpack-dev-middleware')(compiler, {
   noInfo: true,
   publicPath: config.output.publicPath

--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -30,11 +30,17 @@ app.use(require('webpack-dev-middleware')(compiler, {
   publicPath: config.output.publicPath
 }))
 
-app.use(require('webpack-hot-middleware')(compiler))
+if (serverConfig.hot) {
+  app.use(require('webpack-hot-middleware')(compiler))
+}
+
+if (serverConfig.contentBase) {
+  app.use(express.static(serverConfig.contentBase))
+}
 
 app.listen(serverConfig.port, serverConfig.host, function (err) {
   if (err) {
-    console.log(err)
+    console.error(err)
     return
   }
 

--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+// Based on
+// https://github.com/gaearon/react-transform-boilerplate/blob/master/devServer.js
+
+var path = require('path')
+var express = require('express')
+var webpack = require('webpack')
+
+var configFile = process.argv[2]
+var config
+try {
+  config = require(path.join(process.cwd(), configFile))
+} catch (e) {
+  console.error(e.stack)
+  console.error(
+    'Failed to load webpack config, please use like this\n' +
+    'hjs-dev-server.js webpack.config.js\n'
+  )
+  process.exit(1)
+}
+
+var serverConfig = config.devServer
+
+var app = express()
+var compiler = webpack(config)
+console.log(JSON.stringify(config.module, null, 2))
+app.use(require('webpack-dev-middleware')(compiler, {
+  noInfo: true,
+  publicPath: config.output.publicPath
+}))
+
+app.use(require('webpack-hot-middleware')(compiler))
+
+app.listen(serverConfig.port, serverConfig.host, function (err) {
+  if (err) {
+    console.log(err)
+    return
+  }
+
+  console.log('Listening at http://' + serverConfig.host + ':' + serverConfig.port)
+})

--- a/examples/assets-and-index-html/.babelrc
+++ b/examples/assets-and-index-html/.babelrc
@@ -1,19 +1,3 @@
 {
-  "presets": ["es2015", "react"],
-  "env": {
-    "development": {
-      "plugins": [
-        ["react-transform", {
-          "transforms": [{
-            "transform": "react-transform-hmr",
-            "imports": ["react"],
-            "locals": ["module"]
-          }, {
-            "transform": "react-transform-catch-errors",
-            "imports": ["react", "redbox-react"]
-          }]
-        }]
-      ]
-    }
-  }
+  "presets": ["es2015", "react"]
 }

--- a/examples/assets-and-index-html/.babelrc
+++ b/examples/assets-and-index-html/.babelrc
@@ -1,3 +1,19 @@
 {
-    "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "env": {
+    "development": {
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }, {
+            "transform": "react-transform-catch-errors",
+            "imports": ["react", "redbox-react"]
+          }]
+        }]
+      ]
+    }
+  }
 }

--- a/examples/assets-and-index-html/package.json
+++ b/examples/assets-and-index-html/package.json
@@ -10,6 +10,7 @@
     "babel": "^6.1.18",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
+    "babel-plugin-react-transform": "^2.0.0-beta1",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "css-loader": "^0.23.0",
@@ -18,17 +19,21 @@
     "postcss-loader": "^0.8.0",
     "react-dom": "^0.14.3",
     "react-hot-loader": "^1.3.0",
+    "react-transform-catch-errors": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
+    "redbox-react": "^1.0.1",
     "style-loader": "^0.13.0",
     "stylus-loader": "^1.4.2",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0",
+    "webpack-hot-middleware": "^2.6.0",
     "yeticss": "^7.0.5"
   },
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "../../bin/hjs-dev-server.js webpack.config.js",
     "build": "webpack"
   }
 }

--- a/examples/assets-and-index-html/package.json
+++ b/examples/assets-and-index-html/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "../../bin/hjs-dev-server.js webpack.config.js",
+    "start": "hjs-dev-server webpack.config.js",
     "build": "webpack"
   }
 }

--- a/examples/assets-and-index-html/package.json
+++ b/examples/assets-and-index-html/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "hjs-dev-server webpack.config.js",
+    "start": "hjs-dev-server",
     "build": "webpack"
   }
 }

--- a/examples/just-assets-no-html/package.json
+++ b/examples/just-assets-no-html/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "hjs-dev-server webpack.config.js",
+    "start": "hjs-dev-server",
     "build": "NODE_ENV=production webpack"
   }
 }

--- a/examples/just-assets-no-html/package.json
+++ b/examples/just-assets-no-html/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "hjs-dev-server webpack.config.js",
     "build": "NODE_ENV=production webpack"
   }
 }

--- a/examples/just-assets-no-html/webpack.config.js
+++ b/examples/just-assets-no-html/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = getConfig({
   html: false,
   clearBeforeBuild: true,
   devServer: {
+    hot: false,
     contentBase: __dirname
   }
 })

--- a/examples/prerendered-html-files/package.json
+++ b/examples/prerendered-html-files/package.json
@@ -11,6 +11,7 @@
     "babel": "^6.1.18",
     "babel-core": "^6.2.1",
     "babel-loader": "^6.2.0",
+    "babel-plugin-react-transform": "^2.0.0-beta1",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-react": "^6.1.18",
     "css-loader": "^0.23.0",
@@ -18,16 +19,20 @@
     "postcss-loader": "^0.8.0",
     "react-dom": "^0.14.3",
     "react-hot-loader": "^1.3.0",
+    "react-transform-catch-errors": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
+    "redbox-react": "^1.2.0",
     "style-loader": "^0.13.0",
     "stylus-loader": "^1.4.2",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0",
+    "webpack-hot-middleware": "^2.6.0",
     "yeticss": "^7.0.5"
   },
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "webpack-dev-server",
+    "start": "hjs-dev-server webpack.config.js",
     "build": "webpack"
   }
 }

--- a/examples/prerendered-html-files/package.json
+++ b/examples/prerendered-html-files/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "main": "app.js",
   "scripts": {
-    "start": "hjs-dev-server webpack.config.js",
+    "start": "hjs-dev-server",
     "build": "webpack"
   }
 }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var isInstalled = require('./lib/is-installed')
 
 // figure out if we're running `webpack` or `webpack-dev-server`
 // we'll use this as the default for `isDev`
-var isDev = (process.argv[1] || '').indexOf('webpack-dev-server') !== -1
+var isDev = (process.argv[1] || '').indexOf('hjs-dev-server') !== -1
 
 module.exports = function (opts) {
   checkRequired(opts)
@@ -45,7 +45,10 @@ module.exports = function (opts) {
       // which is why we also do the manual entry above and the
       // manual adding of the hot module replacment plugin below
       hot: true,
-      contentBase: outputFolder
+      contentBase: outputFolder,
+      port: 3000,
+      hostname: 'localhost',
+      https: false
     })
   })
 
@@ -95,8 +98,7 @@ module.exports = function (opts) {
 
     // add dev server and hotloading clientside code
     config.entry.unshift(
-      'webpack-dev-server/client?' + (spec.https ? 'https://' : 'http://') + spec.hostname + ':' + spec.port,
-      'webpack/hot/only-dev-server'
+      'webpack-hot-middleware/client'
     )
 
     config.devServer = spec.devServer
@@ -106,17 +108,36 @@ module.exports = function (opts) {
 
     // add dev plugins
     config.plugins = config.plugins.concat([
-      new webpack.HotModuleReplacementPlugin()
+      new webpack.HotModuleReplacementPlugin(),
+      new webpack.NoErrorsPlugin()
     ])
 
     // add react-hot as module loader if it is installed
-    if (isInstalled('react-hot-loader') && config.spec.devServer.hot) {
-      config.module.loaders.forEach(function (loader) {
-        var loaders = loader.loaders || []
-        if (loaders.indexOf('babel-loader') > -1 || loaders.indexOf('coffee-loader') > -1) {
-          loaders.unshift('react-hot')
-        }
-      })
+    if (isInstalled('babel-loader') &&
+        isInstalled('babel-plugin-react-transform') &&
+        isInstalled('react-transform-catch-errors') &&
+        isInstalled('react-transform-hmr') &&
+        isInstalled('redbox-react') &&
+        isInstalled('webpack-hot-middleware') &&
+        config.spec.devServer.hot) {
+      // var index = Object.keys(config.module.loaders).find(function (i) {
+      //   console.log(config.module.loaders[i])
+      //   return config.module.loaders[i].loader === 'babel-loader'
+      // })[0]
+      // console.log(Object.keys(config.module.loaders), index)
+      // console.log(config.module)
+      // config.module.loaders[index].query = {
+      //   plugins: ['react-transform', {
+      //     transforms: [{
+      //       transform: 'react-transform-hmr',
+      //       imports: ['react'],
+      //       locals: ['module']
+      //     }, {
+      //       transform: 'react-transform-catch-errors',
+      //       imports: ['react', 'redbox-react']
+      //     }]
+      //   }]
+      // }
     }
 
     // Add optional loaders

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var getBaseConfig = require('./lib/base-config')
 var getPackage = require('./lib/get-package')
 var installedStyleLoaders = require('./lib/installed-style-loaders')
-var isInstalled = require('./lib/is-installed')
+var installedHotLoaders = require('./lib/installed-hot-loaders')
 
 // figure out if we're running `webpack` or `webpack-dev-server`
 // we'll use this as the default for `isDev`
@@ -112,32 +112,9 @@ module.exports = function (opts) {
       new webpack.NoErrorsPlugin()
     ])
 
-    // add react-hot as module loader if it is installed
-    if (isInstalled('babel-loader') &&
-        isInstalled('babel-plugin-react-transform') &&
-        isInstalled('react-transform-catch-errors') &&
-        isInstalled('react-transform-hmr') &&
-        isInstalled('redbox-react') &&
-        isInstalled('webpack-hot-middleware') &&
-        config.spec.devServer.hot) {
-      // var index = Object.keys(config.module.loaders).find(function (i) {
-      //   console.log(config.module.loaders[i])
-      //   return config.module.loaders[i].loader === 'babel-loader'
-      // })[0]
-      // console.log(Object.keys(config.module.loaders), index)
-      // console.log(config.module)
-      // config.module.loaders[index].query = {
-      //   plugins: ['react-transform', {
-      //     transforms: [{
-      //       transform: 'react-transform-hmr',
-      //       imports: ['react'],
-      //       locals: ['module']
-      //     }, {
-      //       transform: 'react-transform-catch-errors',
-      //       imports: ['react', 'redbox-react']
-      //     }]
-      //   }]
-      // }
+    // Add react-hot module loader if it is installed
+    if (config.spec.devServer.hot) {
+      installedHotLoaders.load(config)
     }
 
     // Add optional loaders

--- a/index.js
+++ b/index.js
@@ -96,24 +96,14 @@ module.exports = function (opts) {
     // build speed and good rebuild speed
     config.devtool = 'cheap-module-eval-source-map'
 
-    // add dev server and hotloading clientside code
-    config.entry.unshift(
-      'webpack-hot-middleware/client'
-    )
-
     config.devServer = spec.devServer
     config.devServer.port = spec.port
     config.devServer.host = spec.hostname
     config.devServer.https = spec.https
 
-    // add dev plugins
-    config.plugins = config.plugins.concat([
-      new webpack.HotModuleReplacementPlugin(),
-      new webpack.NoErrorsPlugin()
-    ])
-
     // Add react-hot module loader if it is installed
     if (config.spec.devServer.hot) {
+      // configure babel loader
       installedHotLoaders.load(config)
     }
 

--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -51,7 +51,7 @@ module.exports = function getBaseConfig (spec) {
       config: {
         test: /\.(js|jsx|babel)$/,
         exclude: /node_modules/,
-        loaders: ['babel-loader']
+        loader: 'babel-loader'
       }
     },
     {

--- a/lib/installed-hot-loaders.js
+++ b/lib/installed-hot-loaders.js
@@ -1,3 +1,4 @@
+var webpack = require('webpack')
 var isInstalled = require('./is-installed')
 
 var baseLoaders = [
@@ -19,13 +20,13 @@ if (someBaseLoadersInstalled && !allBaseLoadersInstalled) {
 
 function findBabelLoader (config) {
   return Object.keys(config.module.loaders).find(function (i) {
-    console.log(config.module.loaders[i])
     return config.module.loaders[i].loader === 'babel-loader'
   })[0]
 }
 
 function load (config) {
   if (!allBaseLoadersInstalled) {
+    config.devServer.hot = false
     return
   }
 
@@ -45,6 +46,17 @@ function load (config) {
       }]
     ]
   }
+
+  // add hot loading clientside code
+  config.entry.unshift(
+    'webpack-hot-middleware/client'
+  )
+
+  // add dev plugins
+  config.plugins = config.plugins.concat([
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoErrorsPlugin()
+  ])
 }
 
 module.exports = {

--- a/lib/installed-hot-loaders.js
+++ b/lib/installed-hot-loaders.js
@@ -25,6 +25,10 @@ function findBabelLoader (config) {
 }
 
 function load (config) {
+  if (!allBaseLoadersInstalled) {
+    return
+  }
+
   var index = findBabelLoader(config)
 
   config.module.loaders[index].query = {

--- a/lib/installed-hot-loaders.js
+++ b/lib/installed-hot-loaders.js
@@ -1,0 +1,48 @@
+var isInstalled = require('./is-installed')
+
+var baseLoaders = [
+  'babel-loader',
+  'babel-plugin-react-transform',
+  'react-transform-catch-errors',
+  'react-transform-hmr',
+  'redbox-react',
+  'webpack-hot-middleware'
+]
+
+// First check if any but not all of the base loaders are installed
+var someBaseLoadersInstalled = baseLoaders.some(isInstalled)
+var allBaseLoadersInstalled = baseLoaders.every(isInstalled)
+
+if (someBaseLoadersInstalled && !allBaseLoadersInstalled) {
+  throw new Error('The following loaders must all be installed together: ' + baseLoaders.join(', '))
+}
+
+function findBabelLoader (config) {
+  return Object.keys(config.module.loaders).find(function (i) {
+    console.log(config.module.loaders[i])
+    return config.module.loaders[i].loader === 'babel-loader'
+  })[0]
+}
+
+function load (config) {
+  var index = findBabelLoader(config)
+
+  config.module.loaders[index].query = {
+    plugins: [
+      ['react-transform', {
+        transforms: [{
+          transform: 'react-transform-hmr',
+          imports: ['react'],
+          locals: ['module']
+        }, {
+          transform: 'react-transform-catch-errors',
+          imports: ['react', 'redbox-react']
+        }]
+      }]
+    ]
+  }
+}
+
+module.exports = {
+  load: load
+}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,17 @@
     "rimraf": "^2.4.4"
   },
   "devDependencies": {
+    "babel-loader": "^6.2.0",
+    "babel-plugin-react-transform": "^1.1.1",
+    "express": "^4.13.3",
     "precommit-hook": "^3.0.0",
+    "react-transform-catch-errors": "^1.0.0",
+    "react-transform-hmr": "^1.0.1",
     "standard": "5.4.1",
+    "stylus-loader": "^1.4.2",
     "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "webpack-dev-server": "^1.14.0",
+    "webpack-hot-middleware": "^2.6.0"
   },
   "homepage": "https://github.com/henrikjoreteg/hjs-webpack",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -15,17 +15,11 @@
     "rimraf": "^2.4.4"
   },
   "devDependencies": {
-    "babel-loader": "^6.2.0",
-    "babel-plugin-react-transform": "^1.1.1",
     "express": "^4.13.3",
     "precommit-hook": "^3.0.0",
-    "react-transform-catch-errors": "^1.0.0",
-    "react-transform-hmr": "^1.0.1",
     "standard": "5.4.1",
-    "stylus-loader": "^1.4.2",
     "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0",
-    "webpack-hot-middleware": "^2.6.0"
+    "webpack-dev-middleware": "^1.4.0"
   },
   "homepage": "https://github.com/henrikjoreteg/hjs-webpack",
   "keywords": [
@@ -35,8 +29,8 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "peerDependencies": {
-    "webpack-dev-server": "*"
+  "bin": {
+    "hjs-dev-server": "bin/hjs-dev-server.js"
   },
   "pre-commit": [
     "lint",


### PR DESCRIPTION
This is the PR for resolving #65. I tried to do the following things

* Provide own binary `hjs-dev-server` which replaces `webpack-dev-server`
* Make upgrading as simple as possible
* Upgrade two examples to use the new hot reloading (`assets-and-index-html`, `prerendered-html-files) and upgrade one to not use hot reloading (`just-assets-no-html`)
* Add upgrade guide in the readme

Things are working well for me locally, but now I need some more eyes on this, especially to check if this is all in line with the project. 

**Update:** Still missing `https` support at the moment.