### PR TITLE
check for preset and use full hot middleware entry path

### DIFF
--- a/lib/installed-hot-loaders.js
+++ b/lib/installed-hot-loaders.js
@@ -1,4 +1,5 @@
 var webpack = require('webpack')
+var path = require('path')
 var isInstalled = require('./is-installed')
 
 var baseLoaders = [
@@ -13,20 +14,22 @@ var preset = 'babel-preset-react-hmre'
 // First check if any but not all of the base loaders are installed
 var someBaseLoadersInstalled = baseLoaders.some(isInstalled)
 var allBaseLoadersInstalled = baseLoaders.every(isInstalled)
+var presetInstalled = isInstalled(preset)
 
-if (someBaseLoadersInstalled && !allBaseLoadersInstalled && !isInstalled(preset)) {
+if (someBaseLoadersInstalled && !allBaseLoadersInstalled && !presetInstalled) {
   throw new Error('`' + baseLoaders.join(' ') + '` must all be installed together or `' + preset + '` must be installed')
 }
 
 function load (config) {
-  if (!allBaseLoadersInstalled) {
+  if (!allBaseLoadersInstalled && !presetInstalled) {
     config.devServer.hot = false
     return
   }
 
   // add hot loading clientside code
   config.entry.unshift(
-    'webpack-hot-middleware/client'
+    // Full path to webpack-hot-middleware so it works in npm2 and npm3
+    path.join(path.dirname(require.resolve('webpack-hot-middleware')), 'client')
   )
 
   // add dev plugins


### PR DESCRIPTION
There were two issues with using hmr this on npm2:

1. We were resetting the hot flag on the config if all the base loaders were not resolvable. npm3 moves all the base loaders to the top level so no problem there, but npm2 leaves them nested. The fix was to check if the preset was resolvable like we do before throwing the warning error.
2. We list `webpack-hot-middleware` as a dep so we can avoid having the user need to install one more thing. But again on npm2 the middleware couldn't be found since it was nested. The fix was to resolve this as well with `require.resolve`.

fixes #161