### PR TITLE
Add option for setting user-scalable to "yes"

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Your `html` function will be called with a context object that contains the foll
   - `{charset: 'utf-8'}` what charset to set
   - `{title: 'your app'}` sets `<title>`
   - `{head: 'any string'}` anything else you want to put in the `head`, other meta tags, or whatnot.
-  - `{metaViewport: false}` set to false if you don't want the default viewport tag
+  - `{metaViewport: boolean|object}` set to false if you don't want the default viewport tag. Set to an object with `userScalable` true if you don't want to block user-zoom on mobile
   - `{publicPath: 'http://mycdn.com/'}`  (default `/`) pass in path that will prefix the generated css/js files in the template. Note, there is `output.publicPath` provided by webpack, but doesn't easily allow for switching based on envirnoment. In this method we've got access to `context.isDev` and can easily switch based on that.
   - `{metaTags: {}}` lets you easily add `<meta>` tags to the document head. Takes an object where the key is the `name` and the value is the `content`.
   - `{lang: 'en-US'}` sets the `lang` attribute on the `<html>` tag.

--- a/lib/html-plugin.js
+++ b/lib/html-plugin.js
@@ -4,7 +4,9 @@ var assign = require('lodash.assign')
 function defaultHtml (incomingData) {
   var data = assign({
     charset: 'utf-8',
-    metaViewport: true,
+    metaViewport: {
+      userScalable: false
+    },
     html: '<div id="root"></div>',
     publicPath: '/'
   }, incomingData)
@@ -19,7 +21,10 @@ function defaultHtml (incomingData) {
   add('<head>')
   add('<meta charset="' + data.charset + '"/>')
   if (data.metaViewport !== false) {
-    add('<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>')
+    var scalable = data.metaViewport.userScalable ? 'yes' : 'no'
+    add('<meta name="viewport" content="width=device-width, ' +
+      'initial-scale=1, ' +
+      'user-scalable=' + scalable + '"/>')
   }
   if (data.metaTags) {
     for (var key in data.metaTags) {


### PR DESCRIPTION
If you want to enable zoom on mobile for UA reasons provide
```
metaViewport: {
    userScalable: true
}
```
as an option to the `defaultHtml` function

Closes #176