### PR TITLE
Move <script> tag inside <body>

### DIFF
--- a/lib/html-plugin.js
+++ b/lib/html-plugin.js
@@ -40,8 +40,8 @@ function defaultHtml (incomingData) {
   if (data.html) {
     add(data.html)
   }
-  add('</body>')
   add('<script src="' + data.publicPath + data.main + '"></script>')
+  add('</body>')
   if (data.lang) {
     add('</html>')
   }


### PR DESCRIPTION
As `document.body` is no longer used as a default mount point,
move `<script>` inside the `<body>` so the DOM validates

Closes #177