### PR TITLE
Add support for http-proxy-middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,31 @@ By default, if you supply an `html` function it will always be used, whether you
 
 Set this option to `false` to only use your `html` function when building for production. Note, that `.isDev` is attached to the context object passed to the `html` function as described above, so alternately you could just use that value to branch your logic within that function. Using this option circumvents the custom `html` function entirely during development.
 
+## Proxy
+
+The dev server uses [http-proxy-middleware](https://www.npmjs.com/package/http-proxy-middleware) to optionally proxy requests to a separate, possibly external, backend server. Proxies can be specified with `devServer.proxy`. This can be a single proxy, or an array of proxies. The proxy context and options are passed directly to `http-proxy-middleware`.
+
+```js
+getConfig({
+  in: 'src/app.js',
+  out: 'public',
+  clearBeforeBuild: true,
+
+  // Use devServer.proxy to specify proxies
+  devServer: {
+    proxy: {
+      context: "/api",
+      options: {
+        target: "http://localhost:3001",
+        pathRewrite: {
+          "^/api": ""
+        }
+      }
+    }
+  }
+})
+```
+
 ## Developing on multiple devices at once
 
 If you're building an app that you want to look good on all devices it's nice to be able to run them all at once.

--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -8,6 +8,7 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var assign = require('lodash.assign')
+var httpProxyMiddleware = require("http-proxy-middleware");
 
 var configFile = process.argv[2] || 'webpack.config.js'
 var config
@@ -46,6 +47,18 @@ if (https) {
 
 var compiler = webpack(config)
 
+if (serverConfig.proxy) {
+  if (!Array.isArray(serverConfig.proxy)) {
+    serverConfig.proxy = [serverConfig.proxy]
+  }
+  serverConfig.proxy.forEach(function(proxyConfig) {
+    var proxy = proxyMiddleware(proxyConfig.context, proxyConfig.options)
+    app.use(function(req, res, next) {
+      next();
+    }, proxy);
+  });
+}
+
 if (serverConfig.historyApiFallback) {
   app.use(require('connect-history-api-fallback')({
     verbose: false
@@ -62,7 +75,7 @@ if (serverConfig.contentBase) {
   app.use(express.static(serverConfig.contentBase))
 }
 
-server.listen(serverConfig.port, serverConfig.hostname, function (err) {
+server.listen(serverConfig.port, serverConfig.hostname, function(err) {
   if (err) {
     console.error(err)
     return

--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -8,7 +8,7 @@ var path = require('path')
 var express = require('express')
 var webpack = require('webpack')
 var assign = require('lodash.assign')
-var httpProxyMiddleware = require("http-proxy-middleware");
+var httpProxyMiddleware = require('http-proxy-middleware')
 
 var configFile = process.argv[2] || 'webpack.config.js'
 var config
@@ -51,12 +51,12 @@ if (serverConfig.proxy) {
   if (!Array.isArray(serverConfig.proxy)) {
     serverConfig.proxy = [serverConfig.proxy]
   }
-  serverConfig.proxy.forEach(function(proxyConfig) {
-    var proxy = proxyMiddleware(proxyConfig.context, proxyConfig.options)
-    app.use(function(req, res, next) {
-      next();
-    }, proxy);
-  });
+  serverConfig.proxy.forEach(function (proxyConfig) {
+    var proxy = httpProxyMiddleware(proxyConfig.context, proxyConfig.options)
+    app.use(function (req, res, next) {
+      next()
+    }, proxy)
+  })
 }
 
 if (serverConfig.historyApiFallback) {
@@ -75,7 +75,7 @@ if (serverConfig.contentBase) {
   app.use(express.static(serverConfig.contentBase))
 }
 
-server.listen(serverConfig.port, serverConfig.hostname, function(err) {
+server.listen(serverConfig.port, serverConfig.hostname, function (err) {
   if (err) {
     console.error(err)
     return

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "^4.13.4",
     "extract-text-webpack-plugin": "^1.0.1",
     "find-root": "^1.0.0",
+    "http-proxy-middleware": "^0.13.0",
     "lodash.assign": "^4.0.6",
     "lodash.defaults": "^4.0.1",
     "lodash.pick": "^4.1.0",


### PR DESCRIPTION
The webpack-dev-server has support for proxies, but this feature seems to be missing from hjs-webpack so I figured it'd be nice to add that too :)