### PR TITLE
Add CORS headers to response on static files served by dev server

### DIFF
--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -77,6 +77,14 @@ if (serverConfig.hot) {
 }
 
 if (serverConfig.contentBase) {
+  var allowCrossDomain = function(req, res, next) {
+      res.header('Access-Control-Allow-Origin', '*');
+      res.header('Access-Control-Allow-Methods', 'GET,OPTIONS');
+      res.header('Access-Control-Allow-Headers', 'Content-Type');
+
+      next();
+  }
+  app.use(allowCrossDomain);
   app.use(express.static(serverConfig.contentBase))
 }
 


### PR DESCRIPTION
This is maybe an edge case, but I have several times run into CORS trouble when requesting static files from the dev server from the main js script when the main js script is run on a page on a different domain. This pull request should solve that.
