### PR TITLE
Support for sending non-HMR file change events to the client

### DIFF
--- a/bin/hjs-dev-server.js
+++ b/bin/hjs-dev-server.js
@@ -73,7 +73,14 @@ if (serverConfig.historyApiFallback) {
 app.use(require('webpack-dev-middleware')(compiler, serverConfig))
 
 if (serverConfig.hot) {
-  app.use(require('webpack-hot-middleware')(compiler))
+  var hotMiddleware = require('webpack-hot-middleware')(compiler)
+  if (serverConfig.customWatch) {
+    Object.keys(serverConfig.customWatch).forEach(type => {
+      chokidar.watch(serverConfig.customWatch[type], {ignoreInitial: true})
+      .on('all', (event, file) => hotMiddleware.publish({type, file}))
+    })
+  }
+  app.use(hotMiddleware)
 }
 
 if (serverConfig.contentBase) {


### PR DESCRIPTION
This is supporting the case of files modified by plugins (CopyWebpackPlugin, HtmlWebpackPlugin) that can't be sent via HMR because they're not required in a bundle. A simple case is documented [here](https://github.com/kevlened/copy-webpack-plugin/issues/1).

The config might look something like
```
if (config.devServer) {
    config.devServer.customWatch = {
        jade: 'src/**.jade'
    }
}
```
and it's assumed that sending the object key and changed file path to the client is sufficient to respond with something like
```
if (NODE_ENV === "development") {
    var webpackHotMiddlewareClient = require('webpack-hot-middleware/client')

    webpackHotMiddlewareClient.subscribe((e) => {
        if (e.type === 'jade') {
            window.location.reload()
        }
    })
}
```

The approach is currently naive (I've even left out the chokidar dependency!) I'm just hoping to start a discussion about solving a case that doesn't fit within HMR but nonetheless seems to cause a certain amount of headache.