### PR TITLE
use pug-loader instead of jade-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here's some more information about the available loaders and plugins and what th
 
 #### Templates
 
-[`jade-loader`](https://www.npmjs.com/package/jade-loader) Require jade files as compiled functions. Extension: `jade`.
+[`pug-loader`](https://www.npmjs.com/package/pug-loader) Require pug files as compiled functions. Extension: `pug` (legacy `jade` also supported).
 
 #### Development
 

--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -132,6 +132,13 @@ module.exports = function getBaseConfig (spec) {
       }
     },
     {
+      pkg: 'jade-loader',
+      config: {
+        test: /\.jade$/,
+        loaders: ['jade']
+      }
+    },
+    {
       pkg: 'pug-loader',
       config: {
         test: /\.(pug|jade)$/,

--- a/lib/base-config.js
+++ b/lib/base-config.js
@@ -132,10 +132,10 @@ module.exports = function getBaseConfig (spec) {
       }
     },
     {
-      pkg: 'jade-loader',
+      pkg: 'pug-loader',
       config: {
-        test: /\.jade$/,
-        loaders: ['jade']
+        test: /\.(pug|jade)$/,
+        loaders: ['pug']
       }
     }
   ]


### PR DESCRIPTION
jade had to be renamed to pug, see https://github.com/pugjs/pug/issues/2184 for more details.

This commit will replace `jade-loader` with `pug-loader`, which supports the
extensions `.pug` and `.jade` for backwards compatibility.