### PR TITLE
Retain environment variables in production

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ module.exports = function (opts) {
         allChunks: true
       }),
       new webpack.DefinePlugin({
-        'process.env': {NODE_ENV: JSON.stringify('production')}
+        'process.env.NODE_ENV': '"production"'
       })
     )
 


### PR DESCRIPTION
Is there a good reason why we replace all environment variables in production with `NODE_ENV: "production"`? I use hjs-webpack to build server-side code and need to be able to read environment variables. I suggest that we only replace `process.env.NODE_ENV` with `"production"`  instead.