### PR TITLE
Honor the plugins option in postcss.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 9.1.0
+  - Add support for using `postcss.config.js` to configure PostCSS
+
 ### 9.0.0
   - Add support for webpack 2. Although there are no differences in the API, this version requires you
   to migrate to webpack@^2.2.1. You will also have to update your loader dependencies to their newest majors

--- a/lib/installed-style-loaders.js
+++ b/lib/installed-style-loaders.js
@@ -1,11 +1,37 @@
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var isInstalled = require('./is-installed')
 
+var postCssOptions = {}
+var hasInstalledAutoprefixer = isInstalled('autoprefixer')
+
+try {
+  // look for a config file and use its contents
+  postCssOptions = require(process.cwd() + '/postcss.config.js')
+
+  // our label says autoprefixer is included, so we should support that
+  // plugin not being defined even if there is a config file
+  if (hasInstalledAutoprefixer) {
+    var isMissingAutoprefixerInPlugins = !postCssOptions.plugins || !postCssOptions.plugins.includes(function (plugin) {
+      plugin.postcssPlugin === 'autoprefixer'
+    })
+
+    if (isMissingAutoprefixerInPlugins) {
+      if (!postCssOptions.plugins) {
+        postCssOptions.plugins = [require('autoprefixer')]
+      } else {
+        postCssOptions.plugins.push(require('autoprefixer'))
+      }
+    }
+  }
+} catch (e) {
+  postCssOptions = {
+    plugins: hasInstalledAutoprefixer ? [require('autoprefixer')] : []
+  }
+}
+
 var postcssLoaderWithPlugins = {
   loader: 'postcss-loader',
-  options: {
-    plugins: isInstalled('autoprefixer') ? [require('autoprefixer')] : []
-  }
+  options: postCssOptions
 }
 
 var stylusLoaderWithPlugins = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hjs-webpack",
   "description": "Presets for setting up webpack with hotloading react and ES6(2015) using Babel.",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "bin": {
     "hjs-dev-server": "bin/hjs-dev-server.js"


### PR DESCRIPTION
This is a proposed solution for issue #326 

Look for a `postcss.config.js` file in the cwd of the process running hjs-webpack (typically the same as `package.json` where PostCSS expects the file to be) and use it to build the options given to the loader. 

This change lets users define custom PostCSS-plugins via `postcss.config.js` instead of modifying the config generated by `hjs-webpack`. 