### PR TITLE
Add support for several different NODE_ENV values

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ module.exports = function (opts) {
         allChunks: true
       }),
       new webpack.DefinePlugin({
-        'process.env.NODE_ENV': '"production"'
+        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'production')
       })
     )
 


### PR DESCRIPTION
This commit adds support for using different NODE_ENV values than
"production" when running the `DefinePlugin`. It now sets `NODE_ENV`
to whatever the environment variable `NODE_ENV` is, and defaults to
"production" if `NODE_ENV` is not set.

Fixes #328.